### PR TITLE
Move up "Compiler/Linker Flags" section in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,18 @@
 # along with MathTrader++.  If not, see <http://www.gnu.org/licenses/>.
 
 #===============================#
+#	Compiler/Linker Flags	#
+#===============================#
+
+CXX      = g++
+DBGFLAGS = -g
+OPTIM    = -O3
+INCLUDE  = -I $(INCDIR)
+CXXFLAGS = $(OPTIM) $(INCLUDE) -Wall -Wextra -std=c++11
+LDFLAGS  = -lemon
+
+
+#===============================#
 #	Directories		#
 #===============================#
 
@@ -62,18 +74,6 @@ EXECUTABLES = mathtrader++
 ###
 DOXYBIN	 = doxygen
 DOXYFILE = $(CFGDIR)/doxyfile.cfg
-
-
-#===============================#
-#	Compiler/Linker Flags	#
-#===============================#
-
-CXX      = g++
-DBGFLAGS = -g
-OPTIM    = -O3
-INCLUDE  = -I $(INCDIR)
-CXXFLAGS = $(OPTIM) $(INCLUDE) -Wall -Wextra -std=c++11 -Wno-strict-aliasing
-LDFLAGS  = -lemon
 
 
 #===============================#


### PR DESCRIPTION
The "Directories" and "Files" sections are mostly static and (especially "Files") usually don't need any modification by the user, while the "Compiler/Linker Flags" might very well require some edits from the user, so move it up to be easier and faster accessible.
